### PR TITLE
get value from resource, rather than uninstantiated local variable

### DIFF
--- a/providers/pkg.rb
+++ b/providers/pkg.rb
@@ -56,7 +56,7 @@ action :install do
 
     inst_type_code =
         if new_resource.inst_type
-            "--inst-type #{inst_type}"
+            "--inst-type #{new_resource.inst_type}"
         else
             ""
         end


### PR DESCRIPTION
When defining node[:alertlogic][:agent][:inst_type], chef convergeance fails due to #{inst_type} being uninstantiated... need to get the value from the resource call.
