### PR TITLE
pin rsyslog to version 2.2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ issues_url 'https://github.com/alertlogic/al_agents/issues'
 license 'All rights reserved'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.6'
+version '1.0.7'
 
 depends 'selinux_policy'
-depends 'rsyslog'
+depends 'rsyslog', '= 2.2.0'
 depends 'line'
 
 supports 'debian'


### PR DESCRIPTION
Temporarily pin rsyslog version to avoid no resource exception:
fixes #37 
