### PR TITLE
update attributes to set syslog_ng to use s_all for centos 6 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ al_agents CHANGELOG
 
 This file is used to list changes made in each version of the al_agents cookbook.
 
+1.0.8
+-----
+- Justin Early - Set syslog_ng to use s_all for CentOS version 6 and up
+
 1.0.7
 -----
 - Justin Early - Pin rsyslog cookbook to version 2.2.0

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ when 'rhel', 'fedora'
   if node['platform_version'].to_i >= 6
     default['al_agents']['syslog_ng']['source_log'] = 's_all'
   else
-      default['al_agents']['syslog_ng']['source_log'] = 's_sys'
+    default['al_agents']['syslog_ng']['source_log'] = 's_sys'
   end
   if node['kernel']['machine'] == 'x86_64'
     default['al_agents']['package']['url'] = 'https://scc.alertlogic.net/software/al-agent-LATEST-1.x86_64.rpm'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,11 @@ default['al_agents']['package']['name'] = 'al-agent'
 case node['platform_family']
 when 'rhel', 'fedora'
   default['al_agents']['agent']['service_name'] = 'al-agent'
-  default['al_agents']['syslog_ng']['source_log'] = 's_sys'
+  if node['platform_version'].to_i >= 6
+    default['al_agents']['syslog_ng']['source_log'] = 's_all'
+  else
+      default['al_agents']['syslog_ng']['source_log'] = 's_sys'
+  end
   if node['kernel']['machine'] == 'x86_64'
     default['al_agents']['package']['url'] = 'https://scc.alertlogic.net/software/al-agent-LATEST-1.x86_64.rpm'
   else

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/alertlogic/al_agents/issues'
 license 'All rights reserved'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.7'
+version '1.0.8'
 
 depends 'selinux_policy'
 depends 'rsyslog', '= 2.2.0'


### PR DESCRIPTION
Fixes #39 