### PR TITLE
depricating role mode option durning provisioning phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@ al_agents CHANGELOG
 
 This file is used to list changes made in each version of the al_agents cookbook.
 
+1.1.0
+------
+- Justin Early - Deprecating --inst-type role from provisioning options
+
 1.0.10
 ------
 - Justin Early - pin al-agent package version to >=0 to avoid error in Chef 12
+
 1.0.9
 -----
 - Spencer Owen / Justin Early - Fix windows_guard issue opening .pem file. Fix for_imaging logic

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Attributes
 ----------
 
 * `['al_agents']['agent']['registration_key']` - your required registration key. String defaults to `your_registration_key_here`
-* `['al_agents']['agent']['for_autoscaling']` - The for_autoscaling attribute determines if your installation will be configured as a `host` or `role` server.  By default for_autoscaling is set to `false` or in other words as a `host` install.  If autoscaling is set to `true` then the install is configured as a `role` server. Boolean defaults to `false`
 * `['al_agents']['agent']['for_imaging']` - The `for_imaging` attribute determines if the install process will continue or stop prior to provisioning.  If the `for_imaging` attribute is set to `true` then the install process perform an install only and stop before provisioning.  This allows for instance snapshots to be saved and started for later use.  With this attribute set to `false` then the provisioning process is performed during setup.  Boolean defaults to `false`
 * `['al_agents']['agent']['egress_url']` - By default all traffic is sent to https://vaporator.alertlogic.com:443.  This attribute is useful if you have a machine that is responsible for outbound traffic (NAT box).  If you specify your own URL ensure that it is a properly formatted URI.  String defaults to `https://vaporator.alertlogic.com:443`
 * `['al_agents']['agent']['proxy_url']` - By default al-agent does not require the use of a proxy.  This attribute is useful if you want to avoid a single point of egress.  When a proxy is used, both `['al_agents']['agent']['egress_url']` and `['al_agents']['agent']['proxy_url']` values are required.  If you specify a proxy URL ensure that it is a properly formatted URI.  String defaults to `nil`
@@ -82,14 +81,10 @@ Examples
 
 Configurations
 --------------
-The attributes `for_autoscaling` and `for_imaging` determine your installation type.  They are boolean values and by default both of those values are `false`.  As boolean values, you can create a matrix of four possible configuration outcomes.  It is worth mentioning those configurations.
+The attribute `for_imaging` determine your installation type.  It is a boolean value and by default is `false`.  Setting this value to true will prepare your agent for imaging only and will not provision the agent.
 
-1. host (default) when `for_autoscaling = false` and `for_imaging = false`
-2. host for imaging when `for_autoscaling = false` and `for_imaging = true`
-3. role when `for_autoscaling = true` and `for_imaging = false`
-4. role for imaging when `for_autoscaling = true` and `for_imaging = true`
 
-Performing an agent install using the cookbook's default attributes, will setup the agent as a `host` type and provision the instance immediately. see *configuration #1* above.  If you have properly set your registration key, your host should appear within Alert Logic's Console within 15 minutes.
+Performing an agent install using the cookbook's default attributes, will setup the agent and provision the instance immediately. see *configuration #1* above.  If you have properly set your registration key, your host should appear within Alert Logic's Console within 15 minutes.
 
 Testing
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,8 +6,6 @@ default['al_agents']['agent']['egress_url'] = 'https://vaporator.alertlogic.com:
 
 default['al_agents']['agent']['proxy_url'] = nil
 
-default['al_agents']['agent']['for_autoscaling'] = false
-
 default['al_agents']['agent']['for_imaging'] = false
 
 default['al_agents']['package']['name'] = 'al-agent'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,11 +26,6 @@ module AlAgents
       node['al_agents']['agent']['registration_key']
     end
 
-    # for_autoscaling: role ~> autoscaling = true, host ~> autoscaling = false
-    def for_autoscaling
-      node['al_agents']['agent']['for_autoscaling']
-    end
-
     # for_imaging: configure ~> run just the configure commands, provision ~> run the provision command
     def for_imaging
       node['al_agents']['agent']['for_imaging']
@@ -57,14 +52,6 @@ module AlAgents
       version_value
     end
 
-    def inst_type_value
-      if for_autoscaling
-        'role'
-      else
-        'host'
-      end
-    end
-
     def proxy_url
       node['al_agents']['agent']['proxy_url']
     end
@@ -80,14 +67,14 @@ module AlAgents
     def provision_options
       options = []
       options << "--key #{registration_key}"
-      options << "--inst-type #{inst_type_value}"
+      options << '--inst-type host'
       options.join(' ')
     end
 
     def windows_options
       egress = Chef::Recipe::Egress.new(node)
       windows_options = ["/quiet prov_key=#{registration_key}"]
-      windows_options << "prov_only=#{inst_type_value}" unless for_imaging == false
+      windows_options << 'prov_only=host' unless for_imaging == false
       windows_options << "USE_PROXY=#{proxy_url}" unless proxy_url.nil?
       windows_options << 'install_only=1' if for_imaging
       windows_options << "sensor_host=#{egress.sensor_host}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/alertlogic/al_agents/issues'
 license 'All rights reserved'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.10'
+version '1.1.0'
 
 depends 'selinux_policy'
 depends 'rsyslog', '= 2.2.0'


### PR DESCRIPTION
Removing for_autoscaling option from attributes and helpers as role mode is being deprecated in the next release.