### PR TITLE
Add port for selinux instead of using resource name.  Throws a warnin…

### DIFF
--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -7,6 +7,7 @@
 
 include_recipe 'selinux_policy::install'
 selinux_policy_port '1514' do
+  port 1514
   protocol 'tcp'
   secontext 'syslogd_port_t'
 end


### PR DESCRIPTION
…g every chef-client run that it is depricated and will not work in Chef 13.