### PR TITLE
Update metadata.rb for Chef 11.10 compatibility

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
 name 'al_agents'
 maintainer 'Justin Early'
 maintainer_email 'jearly@alertlogic.com'
-source_url 'https://github.com/alertlogic/al_agents'
-issues_url 'https://github.com/alertlogic/al_agents/issues'
+source_url 'https://github.com/alertlogic/al_agents' if respond_to?(:source_url)
+issues_url 'https://github.com/alertlogic/al_agents/issues' if respond_to?(:issues_url)
 license 'Apache 2.0 License'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
`source_url` and `issues_url` do not exist in Chef 11.10
```
[2016-05-11T22:20:44+00:00] ERROR: Could not read /opt/aws/opsworks/current/merged-cookbooks/al_agents into a Chef object: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x007fa020b432d8>
[2016-05-11T22:20:44+00:00] ERROR: #<NoMethodError: undefined method `to_hash' for nil:NilClass>
```