### PR TITLE
Fixing configure options to avoid 301 redirect loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ al_agents CHANGELOG
 
 This file is used to list changes made in each version of the al_agents cookbook.
 
+1.3.3
+------
+- Justin Early - Adjust configure_options to pass host and port separately.
+
 1.3.2
 ------
 - Fred Reimer - Add port for selinux instead of using resource name

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -64,7 +64,7 @@ module AlAgents
       egress = Chef::Recipe::Egress.new(node)
       options = []
       options << "--proxy #{proxy_url}" unless proxy_url.nil?
-      options << "--host #{egress.host}:#{egress.port}"
+      options << "--host #{egress.host} --port #{egress.port}"
       options.join(' ')
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/alertlogic/al_agents/issues'
 license 'Apache 2.0 License'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.2'
+version '1.3.3'
 
 depends 'selinux_policy'
 depends 'rsyslog', '= 2.2.0'


### PR DESCRIPTION
Fixes #63 

Previous versions of al-agent package would accept host:port without issue. Separating --host and --port in configuration avoids this and allows the agent package to configure and provision correctly.