### PR TITLE
use rpm package library when rhel >=6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ al_agents CHANGELOG
 
 This file is used to list changes made in each version of the al_agents cookbook.
 
+1.3.6
+-----
+- Justin Early - Use rpm package library when rhel >= 6
+
 1.3.5
 -----
 - Andrés Vargas - Make package repository configurable

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/alertlogic/al_agents/issues' if respond_to?(:issu
 license 'Apache 2.0 License'
 description 'Installs/Configures the Alert Logic Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.5'
+version '1.3.6'
 
 depends 'selinux_policy'
 depends 'rsyslog', '= 2.2.0'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,7 +25,7 @@ package agent_basename do
   version '>=0'
   ignore_failure node['al_agents']['agent']['ignore_failure']
   provider Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
-  provider Chef::Provider::Package::Rpm if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 6
+  provider Chef::Provider::Package::Rpm if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 6
 end
 
 include_recipe 'al_agents::configure_agent' unless for_imaging


### PR DESCRIPTION
Workaround for chef versions < 12.2.0.rc.1 
See: https://github.com/chef/chef/pull/3065