### PR TITLE
Update rsyslog cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.3.6'
 
 depends 'selinux_policy'
-depends 'rsyslog', '= 2.2.0'
+depends 'rsyslog', '~> 5.1.0'
 depends 'line'
 
 supports 'debian'

--- a/recipes/rsyslog.rb
+++ b/recipes/rsyslog.rb
@@ -1,5 +1,7 @@
 ::Chef::Recipe.send(:include, AlAgents::Helpers)
 
+include_recipe 'rsyslog'
+
 config_prefix = node['rsyslog']['config_prefix']
 template "#{config_prefix}/rsyslog.d/alertlogic.conf" do
   source 'rsyslog/alertlogic.conf.erb'
@@ -9,8 +11,5 @@ template "#{config_prefix}/rsyslog.d/alertlogic.conf" do
   notifies :restart, "service[#{node['rsyslog']['service_name']}]"
   not_if { ::File.exist?("#{node['rsyslog']['config_prefix']}/rsyslog.d/alertlogic.conf") }
 end
-
-extend RsyslogCookbook::Helpers
-declare_rsyslog_service
 
 node.run_state['logging_by'] = 'rsyslog'


### PR DESCRIPTION
Passed all tests.  Addresses Issue #74 as I had a similar problem in my environment.

Also of note, the windows test kitchen suite fails due to an md5sum mismatch when downloading the chef MSI.  I did not have time to investigate it more thoroughly than that.