### PR TITLE
Add SUSE support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@ default['al_agents']['agent']['ignore_failure'] = false
 default['al_agents']['package']['base_url'] = 'https://scc.alertlogic.net/software/'
 
 case node['platform_family']
-when 'rhel', 'fedora', 'amazon'
+when 'rhel', 'fedora', 'amazon', 'suse'
   default['al_agents']['agent']['al_agent_service'] = 'al-agent'
   default['al_agents']['syslog_ng']['source_log'] = if node['platform_version'].to_i >= 6
                                                       's_all'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -27,9 +27,10 @@ package agent_basename do
   version '>=0'
   ignore_failure node['al_agents']['agent']['ignore_failure']
   provider Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
+  provider Chef::Provider::Package::Rpm if node['platform_family'] == 'suse'
   provider Chef::Provider::Package::Rpm if (
-    node['platform_family'] == 'rhel' &&
-    node['platform_version'].to_i >= 6) || node['platform_family'] == 'amazon'
+  node['platform_family'] == 'rhel' &&
+      node['platform_version'].to_i >= 6) || node['platform_family'] == 'amazon'
 end
 
 include_recipe 'al_agents::configure_agent' unless for_imaging


### PR DESCRIPTION
Adding support for SUSE. (Fixes #86) 

- Add `suse` to `platform` case in default attributes.
- Update installation recipe setting `RPM` as handler for package installation on SUSE.

Let me know if anything further is required.